### PR TITLE
Fix: Use IE11 friendly syntax

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,17 +1,21 @@
 'use strict';
 const decamelize = require('decamelize');
 
-const humanizeString = input => {
+function humanizeString(input) {
 	if (typeof input !== 'string') {
 		throw new TypeError('Expected a string');
 	}
 
-	input = decamelize(input);
-	input = input.toLowerCase().replace(/[_-]+/g, ' ').replace(/\s{2,}/g, ' ').trim();
-	input = input.charAt(0).toUpperCase() + input.slice(1);
-
-	return input;
-};
+	return (
+		decamelize(input)
+			.toLowerCase()
+			.replace(/[_-]+/g, ' ')
+			.replace(/\s{2,}/g, ' ')
+			.trim()
+			.charAt(0)
+			.toUpperCase() + input.slice(1)
+	);
+}
 
 module.exports = humanizeString;
 // TODO: Remove this for the next major release


### PR DESCRIPTION
## Decsription
We are using this library in our client facing application which needs to be IE11 compatible - due to current usage of arrow function - this library is breaking on IE11 - please consider the following changes to support this older browser.
Thank you!

## Dependencies
Because this library depends on https://github.com/sindresorhus/decamelize i've also made PR https://github.com/sindresorhus/decamelize/pull/19 over there with necessary adjustments to make it work in IE11.