### PR TITLE
Add `preserveCase` option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,7 @@
+interface HumanizeProps { 
+	originalCase?: boolean
+}
+
 declare const humanizeString: {
 	/**
 	Convert a camelized/dasherized/underscored string into a humanized one: `fooBar-Baz_Faz` → `Foo bar baz faz`.
@@ -18,7 +22,7 @@ declare const humanizeString: {
 	//=> 'Foo bar'
 	```
 	*/
-	(text: string): string;
+	(text: string, opts: HumanizeProps): string;
 
 	// TODO: Remove this for the next major release, refactor the whole definition to:
 	// declare function humanizeString(text: string): string;

--- a/index.js
+++ b/index.js
@@ -1,13 +1,14 @@
 'use strict';
 const decamelize = require('decamelize');
 
-const humanizeString = input => {
+const humanizeString = (input, opts = {}) => {
 	if (typeof input !== 'string') {
 		throw new TypeError('Expected a string');
 	}
 
-	input = decamelize(input);
-	input = input.toLowerCase().replace(/[_-]+/g, ' ').replace(/\s{2,}/g, ' ').trim();
+	input = opts.originalCase ? input : decamelize(input);
+	input = opts.originalCase ? input : input.toLowerCase();
+	input = input.replace(/[_-]+/g, ' ').replace(/\s{2,}/g, ' ').trim();
 	input = input.charAt(0).toUpperCase() + input.slice(1);
 
 	return input;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,4 +1,4 @@
 import {expectType} from 'tsd';
 import humanizeString = require('.');
 
-expectType<string>(humanizeString('fooBar'));
+expectType<string>(humanizeString('fooBar', { originalCase: true }));

--- a/test.js
+++ b/test.js
@@ -11,4 +11,5 @@ test('main', t => {
 	t.is(humanizeString('-UnicornsAndRainbows'), 'Unicorns and rainbows');
 	t.is(humanizeString('  unicorns  and  rainbows  '), 'Unicorns and rainbows');
 	t.is(humanizeString('unicorns_and-Rainbows_andPonies  '), 'Unicorns and rainbows and ponies');
+	t.is(humanizeString('unicorns_and-Rainbows_andPonies', {originalCase: true}), 'Unicorns and Rainbows andPonies');
 });


### PR DESCRIPTION
Closes #5  

Allows preserving original case for the string conditionally with `orignalCase: true` param
